### PR TITLE
feat: 탈퇴 최종 API (탈퇴 시 데이터 admin 계정으로 이전)

### DIFF
--- a/src/main/java/com/dndoz/PosePicker/Repository/PoseInfoRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/PoseInfoRepository.java
@@ -88,6 +88,10 @@ public interface PoseInfoRepository extends JpaRepository<PoseInfo, Long> {
 	Slice<PoseInfo> findBookmark(@Param("uid") Long uid, Pageable pageable);
 
 	@Query(value =
+		"UPDATE pose_info p SET p.uid = :adminUid WHERE p.uid = :uid", nativeQuery = true)
+	void updateUser(@Param("adminUid") Long adminUid, @Param("uid") Long uid);
+
+	@Query(value =
 		"SELECT p.*, CASE WHEN b.pose_id IS NOT NULL THEN TRUE ELSE FALSE END AS bookmarkCheck " +
 		"FROM pose_info p LEFT JOIN bookmark b ON p.pose_id = b.pose_id AND b.uid = :uid WHERE  p.uid = :uid ", nativeQuery = true)
 	Slice<PoseInfo> findByUId(Pageable pageable, @Param("uid") Long uid);

--- a/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
@@ -16,6 +16,7 @@ import com.dndoz.PosePicker.Dto.PPTokenResponse;
 import com.dndoz.PosePicker.Global.status.StatusCode;
 import com.dndoz.PosePicker.Global.status.StatusResponse;
 import com.dndoz.PosePicker.Repository.BookmarkRepository;
+import com.dndoz.PosePicker.Repository.PoseInfoRepository;
 import com.dndoz.PosePicker.Repository.UserRepository;
 
 import com.dndoz.PosePicker.Repository.WithdrawalRepository;
@@ -54,6 +55,7 @@ public class KakaoService {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final BookmarkRepository bookmarkRepository;
 	private final WithdrawalRepository withdrawalRepository;
+	private final PoseInfoRepository poseInfoRepository;
 
 	/** [1] ios 버전 카카오 로그인 **/
 	//포즈피커 자체 토큰 생성 후 전달
@@ -272,8 +274,14 @@ public class KakaoService {
 			redisTemplate.delete("refresh:"+refreshToken);
 		}
 
-		//북마크 정보 삭제, 탈퇴 사유 저장, 회원 정보 삭제
+		//북마크 정보 삭제, 포즈 사용자 변경, 탈퇴 사유 저장, 회원 정보 삭제
 		bookmarkRepository.deleteByUser(user);
+
+		//탈퇴하려는 사용자 포즈 admin 계정으로 업데이트
+		User adminUser= userRepository.findByEmail("dnd.9th.oz@gmail.com").orElseThrow(NullPointerException::new);
+		poseInfoRepository.updateUser(adminUser.getUid(), user.getUid());
+
+		//회원 정보 삭제
 		userRepository.delete(user);
 
 		//탈퇴사유 저장


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 수정된 기획안 반영

## 💁 무엇이 어떻게 바뀌나요?

탈퇴시 사용자가 업로드한 포즈 데이터를 posepicker Admin 계정으로 이전한 후 탈퇴하도록 구현했습니다. 

## 📆 작업 예정인 것이 있나요 ?

- 

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
